### PR TITLE
Use get_full_path for action URL

### DIFF
--- a/frontendadmin/views.py
+++ b/frontendadmin/views.py
@@ -162,7 +162,7 @@ def add(request, app_label, model_name, mode_name='add',
         form = instance_form()
     template_context = {
         'action': 'add',
-        'action_url': request.build_absolute_uri(),
+        'action_url': request.get_full_path(),
         'model_title': model._meta.verbose_name,
         'form': form
     }
@@ -209,7 +209,7 @@ def change(request, app_label, model_name, instance_id, mode_name='change',
 
     template_context = {
         'action': 'change',
-        'action_url': request.build_absolute_uri(),
+        'action_url': request.get_full_path(),
         'model_title': model._meta.verbose_name,
         'form': form,
     }
@@ -255,7 +255,7 @@ def delete(request, app_label, model_name, instance_id,
 
     template_context = {
         'action': 'delete',
-        'action_url': request.build_absolute_uri(),
+        'action_url': request.get_full_path(),
         'model_title': model._meta.verbose_name,
         'form': form,
     }


### PR DESCRIPTION
...ld_absolute_uri(). This fixes a problem with using fronendadmin on SSL enabled sites where the action URL for forms is created with  build_absolute_uri(). will return a http based URI. In contrast we build the action URL with get_full_path() just returns path of the request so your Web server setup can determine if it is https or not
